### PR TITLE
fix: pretendardGlobal -> pretendard로 변경 사용

### DIFF
--- a/src/styles/global/globalText.css.ts
+++ b/src/styles/global/globalText.css.ts
@@ -7,7 +7,7 @@ import { globalFontFace, style } from '@vanilla-extract/css'
  * 600 : semiBold
  * 700 : bold
  */
-export const pretendard = 'globalPretendard'
+export const pretendard = 'pretendard'
 
 globalFontFace(pretendard, [
     {


### PR DESCRIPTION
- 제목 : fix(71): pretendardGlobal -> pretendard로 변경 사용

## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- pretendard 폰트 사용 이름을 global을 제외한 이름으로 사용

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

- 해당 브랜치에서 수행할 작업 없음

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>
