### PR TITLE
feat(87): nav 팝업 기능 추가 - user nav [DF-87]

### DIFF
--- a/src/features/alarm/AlarmPopup.tsx
+++ b/src/features/alarm/AlarmPopup.tsx
@@ -1,0 +1,28 @@
+import { Box } from '@/shared/ui/Box'
+import { Text } from '@/shared/ui/Text'
+
+export const AlarmPopup: React.FC = () => {
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            style={{ width: '160px', padding: '10px 20px', gap: '10px' }}
+        >
+            <Text fontSize="subHeadline" fontWeight="semibold">
+                알림
+            </Text>
+            <Box display="flex" flexDirection="column">
+                <Text fontSize="subHeadline" color="neutral-80">
+                    트렌드 추천
+                </Text>
+                <Text fontSize="subHeadline">어쩌구 저쩌구 랄랄랄라</Text>
+            </Box>
+            <Box display="flex" flexDirection="column">
+                <Text fontSize="subHeadline" color="neutral-80">
+                    트렌드 분석
+                </Text>
+                <Text fontSize="subHeadline">어쩌구 저쩌구 랄랄랄라</Text>
+            </Box>
+        </Box>
+    )
+}

--- a/src/features/calendar/CalendarPopup.tsx
+++ b/src/features/calendar/CalendarPopup.tsx
@@ -1,0 +1,56 @@
+// component
+import { Box } from '@/shared/ui/Box'
+import { Text } from '@/shared/ui/Text'
+// style
+import { iIconTypes } from './calendarpopup.css'
+
+/**
+ * Navigation -> UserNav -> CalendarPopup 컴포넌트
+ * @returns {JsxElement}
+ */
+
+export const CalendarPopup: React.FC = () => {
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            style={{ width: '250px', padding: '10px 20px', gap: '10px' }}
+        >
+            <Text fontSize="headline" fontWeight="semibold">
+                트렌드 리마인더
+            </Text>
+            <Box>
+                <Box display="flex" alignItems="center" style={{ gap: '5px' }}>
+                    <Box as={'i'} className={iIconTypes.end} />
+                    <Text fontSize="subHeadline" color="neutral-80">
+                        종료
+                    </Text>
+                </Box>
+                <Box display="flex" flexDirection="column">
+                    <Text fontSize="subHeadline" color="neutral-900">
+                        A 분석
+                    </Text>
+                    <Text fontSize="subHeadline" color="neutral-300">
+                        2024.12.31 - 2024.12.31
+                    </Text>
+                </Box>
+            </Box>
+            <Box>
+                <Box display="flex" alignItems="center" style={{ gap: '5px' }}>
+                    <Box as={'i'} className={iIconTypes.now} />
+                    <Text fontSize="subHeadline" color="neutral-80">
+                        현재
+                    </Text>
+                </Box>
+                <Box display="flex" flexDirection="column">
+                    <Text fontSize="subHeadline" color="neutral-900">
+                        B 분석
+                    </Text>
+                    <Text fontSize="subHeadline" color="neutral-300">
+                        2024.12.31 - 2024.12.31
+                    </Text>
+                </Box>
+            </Box>
+        </Box>
+    )
+}

--- a/src/features/calendar/calendarpopup.css.ts
+++ b/src/features/calendar/calendarpopup.css.ts
@@ -1,0 +1,13 @@
+import { colors } from '@/app/token'
+import { styleVariants, style } from '@vanilla-extract/css'
+
+const Iicon = style({
+    width: '6px',
+    height: '6px',
+    borderRadius: '50%',
+})
+
+export const iIconTypes = styleVariants({
+    end: [Iicon, { backgroundColor: colors['red-75'] }],
+    now: [Iicon, { backgroundColor: colors['blue-100'] }],
+})

--- a/src/features/nav/login/button/AlarmBtn.tsx
+++ b/src/features/nav/login/button/AlarmBtn.tsx
@@ -4,15 +4,32 @@ import Bell from '@/shared/asset/icon/bell.svg?react'
 import { Box } from '@/shared/ui/Box'
 // style
 import { defaultBtn } from './btn.css'
+import { usePopup } from '@/shared/lib/hooks/usePopup'
+import { Popup } from '@/shared/ui/Popup'
+import { AlarmPopup } from '@/features/alarm/AlarmPopup'
+import { useRef } from 'react'
+import { useClickOutside } from '@/shared/lib/hooks/useOutsideClick'
 
 /**
  * user Alarm 컴포넌트
  * @returns {JsxElement}
  */
 export const AlarmBtn: React.FC = () => {
+    const { config, togglePopup, hidePopup } = usePopup()
+
+    const ref = useRef<HTMLDivElement>(null) // ref 설정
+    useClickOutside(ref, hidePopup) // 팝업 외부 클릭시 팝업 닫기
     return (
-        <Box as={'button'} className={defaultBtn}>
+        <Box
+            as={'button'}
+            className={defaultBtn}
+            onClick={togglePopup}
+            ref={ref}
+        >
             <Bell width={20} height={20} />
+            <Popup config={config}>
+                <AlarmPopup />
+            </Popup>
         </Box>
     )
 }

--- a/src/features/nav/login/button/CalenderBtn.tsx
+++ b/src/features/nav/login/button/CalenderBtn.tsx
@@ -2,17 +2,34 @@
 import Calnedar from '@/shared/asset/icon/Calendar--Streamline-Tabler-Filled.svg?react'
 // component
 import { Box } from '@/shared/ui/Box'
+import { CalendarPopup } from '@/features/calendar/CalendarPopup'
+import { Popup } from '@/shared/ui/Popup'
 // style
 import { defaultBtn } from './btn.css'
+// hooks
+import { usePopup } from '@/shared/lib/hooks/usePopup'
+import { useClickOutside } from '@/shared/lib/hooks/useOutsideClick'
+import { useRef } from 'react'
 
 /**
  * user Calendar 컴포넌트
  * @returns {JsxElement}
  */
 export const CalendarBtn: React.FC = () => {
+    const { config, togglePopup, hidePopup } = usePopup()
+    const ref = useRef<HTMLButtonElement>(null) // ref 설정
+    useClickOutside(ref, hidePopup) // 팝업 외부 클릭시 팝업 닫기
     return (
-        <Box as={'button'} className={defaultBtn}>
+        <Box
+            as={'button'}
+            className={defaultBtn}
+            ref={ref}
+            onClick={togglePopup}
+        >
             <Calnedar width={20} height={20} />
+            <Popup config={config}>
+                <CalendarPopup />
+            </Popup>
         </Box>
     )
 }

--- a/src/features/nav/login/button/ThemeBtn.tsx
+++ b/src/features/nav/login/button/ThemeBtn.tsx
@@ -4,15 +4,36 @@ import Sun from '@/shared/asset/icon/sun.svg?react'
 import { Box } from '@/shared/ui/Box'
 // style
 import { defaultBtn } from './btn.css'
-
+import { usePopup } from '@/shared/lib/hooks/usePopup'
+import { Popup } from '@/shared/ui/Popup'
+import { Text } from '@/shared/ui/Text'
+import { useRef } from 'react'
+import { useClickOutside } from '@/shared/lib/hooks/useOutsideClick'
 /**
  * user theme 컴포넌트
  * @returns {JsxElement}
  */
 export const ThemeBtn: React.FC = () => {
+    const { config, togglePopup, hidePopup } = usePopup()
+    const ref = useRef<HTMLButtonElement>(null) // ref 설정
+    useClickOutside(ref, hidePopup) // 팝업 외부 클릭시 팝업 닫기
     return (
-        <Box as={'button'} className={defaultBtn}>
+        <Box
+            as={'button'}
+            className={defaultBtn}
+            onClick={togglePopup}
+            ref={ref}
+        >
             <Sun width={20} height={20} />
+            <Box>
+                <Popup config={config}>
+                    <Box style={{ width: '125px', padding: '2px 5px' }}>
+                        <Text fontSize="subHeadline">
+                            다크 모드는 준비중이에요!
+                        </Text>
+                    </Box>
+                </Popup>
+            </Box>
         </Box>
     )
 }

--- a/src/features/nav/login/profile/ProfileOption.tsx
+++ b/src/features/nav/login/profile/ProfileOption.tsx
@@ -47,23 +47,42 @@ export const ProfileOption = () => {
 }
 
 const menu_list = [
-    { logo: <Cog width={16} height={16} />, name: '환경설정', to: '/setting' },
-    { logo: <Call width={16} height={16} />, name: '고객센터', to: '/help' },
-    { logo: <Guide width={16} height={16} />, name: '가이드', to: '/guide' },
+    {
+        logo: <Cog width={16} height={16} />,
+        name: '환경설정',
+        to: '/setting',
+        id: 'nav:po:setting',
+    },
+    {
+        logo: <Call width={16} height={16} />,
+        name: '고객센터',
+        to: '/help',
+        id: 'nav:po:help',
+    },
+    {
+        logo: <Guide width={16} height={16} />,
+        name: '가이드',
+        to: '/guide',
+        id: 'nav:po:guide',
+    },
 ]
 
 export const ProfileOptionMenu = () => {
     return (
         <Box as={'ul'} className={profileOptionMenu}>
-            {menu_list.map((menu, idx) => (
-                <Link to={menu.to} key={idx}>
+            {menu_list.map((menu) => (
+                <Link to={menu.to} key={menu.id}>
                     <Box as={'li'} className={profileOptionMenuCell}>
                         {menu.logo}
                         <Text fontSize="subHeadline">{menu.name}</Text>
                     </Box>
                 </Link>
             ))}
-            <Box as={'li'} className={profileOptionMenuCell}>
+            <Box
+                as={'li'}
+                className={profileOptionMenuCell}
+                key={'nav:po:logout'}
+            >
                 <Logout />
                 <Text fontSize="subHeadline">로그아웃</Text>
             </Box>

--- a/src/features/nav/login/profile/ProfileOption.tsx
+++ b/src/features/nav/login/profile/ProfileOption.tsx
@@ -2,16 +2,71 @@
 import Arrow from '@/shared/asset/icon/cheveron-down.svg?react'
 // component
 import { Box } from '@/shared/ui/Box'
+import { Text } from '@/shared/ui/Text'
+import { Popup } from '@/shared/ui/Popup'
 // style
-import { profileImgBox, profileOptionBox } from './profile.css'
+import {
+    profileImgBox,
+    profileOptionBox,
+    profileOptionMenu,
+    profileOptionMenuCell,
+} from './profile.css'
+// hooks
+import { usePopup } from '@/shared/lib/hooks/usePopup'
+import { useClickOutside } from '@/shared/lib/hooks/useOutsideClick'
+import { useRef } from 'react'
+// svgs
+import Cog from '@/shared/asset/icon/cog.svg?react'
+import Call from '@/shared/asset/icon/phone.svg?react'
+import Guide from '@/shared/asset/icon/color-swatch.svg?react'
+import Logout from '@/shared/asset/icon/logout.svg?react'
+import { Link } from 'react-router-dom'
 
 export const ProfileOption = () => {
+    const { config, togglePopup, hidePopup } = usePopup({ arrow: 'none' })
+    const ref = useRef<HTMLButtonElement>(null)
+    useClickOutside(ref, hidePopup)
     return (
-        <Box display="flex" alignItems="center" className={profileOptionBox}>
-            <Box className={profileImgBox}>
+        <Box
+            display="flex"
+            alignItems="center"
+            className={profileOptionBox}
+            ref={ref}
+        >
+            <Box as={'button'} className={profileImgBox} onClick={togglePopup}>
                 <img src="" alt="" />
             </Box>
-            <Arrow />
+            <Arrow style={config.open ? { rotate: '180deg' } : {}} />
+            <Box>
+                <Popup config={config} LEFT={-100} TOP={30}>
+                    <ProfileOptionMenu />
+                </Popup>
+            </Box>
+        </Box>
+    )
+}
+
+const menu_list = [
+    { logo: <Cog width={16} height={16} />, name: '환경설정', to: '/setting' },
+    { logo: <Call width={16} height={16} />, name: '고객센터', to: '/help' },
+    { logo: <Guide width={16} height={16} />, name: '가이드', to: '/guide' },
+]
+
+export const ProfileOptionMenu = () => {
+    return (
+        <Box as={'ul'} className={profileOptionMenu}>
+            {menu_list.map((menu, idx) => (
+                <Link to={menu.to} key={idx}>
+                    <Box as={'li'} className={profileOptionMenuCell}>
+                        {menu.logo}
+                        <Text fontSize="subHeadline">{menu.name}</Text>
+                    </Box>
+                </Link>
+            ))}
+            <Box as={'li'} className={profileOptionMenuCell}>
+                <Logout />
+                <Text fontSize="subHeadline">로그아웃</Text>
+            </Box>
         </Box>
     )
 }

--- a/src/features/nav/login/profile/profile.css.ts
+++ b/src/features/nav/login/profile/profile.css.ts
@@ -31,3 +31,30 @@ export const notSelect = style({
 export const profileOptionBox = style({
     cursor: 'pointer',
 })
+
+export const profileOptionMenu = style({
+    width: '110px',
+    display: 'flex',
+    flexDirection: 'column',
+})
+
+export const profileOptionMenuCell = style({
+    backgroundColor: colors['neutral-10'],
+    height: '32px',
+    display: 'flex',
+    alignItems: 'center',
+    padding: '6px 10px',
+    gap: '10px',
+    ':hover': {
+        backgroundColor: colors.white,
+        color: colors['teal-500'],
+    },
+    ':first-child': {
+        borderTopLeftRadius: '4px',
+        borderTopRightRadius: '4px',
+    },
+    ':last-child': {
+        borderBottomLeftRadius: '4px',
+        borderBottomRightRadius: '4px',
+    },
+})

--- a/src/shared/lib/hooks/useOutsideClick.ts
+++ b/src/shared/lib/hooks/useOutsideClick.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+
+export const useClickOutside = (
+    ref: React.RefObject<HTMLElement>,
+    handler: (event: MouseEvent | TouchEvent) => void
+) => {
+    useEffect(() => {
+        const listener = (event: MouseEvent | TouchEvent) => {
+            if (!ref.current || ref.current.contains(event.target as Node)) {
+                return
+            }
+            handler(event)
+        }
+        document.addEventListener('mousedown', listener)
+        document.addEventListener('touchstart', listener)
+        return () => {
+            document.removeEventListener('mousedown', listener)
+            document.removeEventListener('touchstart', listener)
+        }
+    }, [ref, handler])
+}

--- a/src/shared/types/popup.types.ts
+++ b/src/shared/types/popup.types.ts
@@ -36,4 +36,5 @@ export type PopupProps = {
     config: IExtendedPopupConfig
     TOP?: number
     LEFT?: number
+    ref?: React.RefObject<HTMLDivElement>
 }

--- a/src/shared/ui/Popup/Popup.tsx
+++ b/src/shared/ui/Popup/Popup.tsx
@@ -1,5 +1,5 @@
 // react
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, forwardRef } from 'react'
 // component
 import { Box } from '../Box'
 // css
@@ -9,41 +9,40 @@ import { PopupProps } from '@/shared/types/popup.types'
 
 /**
  * Popup 컴포넌트
- * @param {React.ReactNode} chidlren children(optional)
+ * @param {React.ReactNode} children children(optional)
  * @param {usePopup} config Popup 설정 객체(required)
  * @param {number} TOP css - position - top(optional)
  * @param {number} LEFT css - position - left(optional)
  * @returns {JsxElement}
  */
-export const Popup: React.FC<PopupProps> = ({
-    children,
-    config,
-    TOP = 0,
-    LEFT = 0,
-}) => {
-    const timerRef = useRef<number | null>(null) // timeout 설정 ref
-    useEffect(() => {
-        if (config.type === 'timer') {
-            if (timerRef.current) {
-                clearTimeout(timerRef.current)
-            } // timeRef 초기화
-            timerRef.current = setTimeout(() => {
-                config.handleClose()
-            }, config.SET_TIMER_MES) // timeout 설정
-        }
-        return () => {
-            if (timerRef.current) clearTimeout(timerRef.current) // 언마운트시 제거
-        }
-    }, [config])
-    if (!config.open) return null
-    return (
-        <Box style={{ position: 'relative' }}>
-            <Box
-                className={popupArrow[config.arrow]}
-                style={{ top: `${TOP}px`, left: `${LEFT}px` }}
-            >
-                {children}
+export const Popup = forwardRef<HTMLDivElement, PopupProps>(
+    ({ children, config, TOP = 0, LEFT = 0 }, ref) => {
+        const timerRef = useRef<number | null>(null) // timeout 설정 ref
+        useEffect(() => {
+            if (config.type === 'timer') {
+                if (timerRef.current) {
+                    clearTimeout(timerRef.current)
+                } // timeRef 초기화
+                timerRef.current = setTimeout(() => {
+                    config.handleClose()
+                }, config.SET_TIMER_MES) // timeout 설정
+            }
+            return () => {
+                if (timerRef.current) clearTimeout(timerRef.current) // 언마운트시 제거
+            }
+        }, [config])
+
+        if (!config.open) return null
+
+        return (
+            <Box style={{ position: 'relative' }} ref={ref}>
+                <Box
+                    className={popupArrow[config.arrow]}
+                    style={{ top: `${TOP}px`, left: `${LEFT}px` }}
+                >
+                    {children}
+                </Box>
             </Box>
-        </Box>
-    )
-}
+        )
+    }
+)

--- a/src/shared/ui/Popup/popup.css.ts
+++ b/src/shared/ui/Popup/popup.css.ts
@@ -5,6 +5,7 @@ const popupDefault = style({
     borderRadius: '4px',
     backgroundColor: '#fff',
     cursor: 'default',
+    zIndex: 10,
 })
 
 const topShadow = style({

--- a/src/widgets/nav/user/UserNav.tsx
+++ b/src/widgets/nav/user/UserNav.tsx
@@ -2,6 +2,6 @@ import { LoginedUserNav } from '@/features/nav/login'
 import { UnLoginedUserNav } from '@/features/nav/unlogin'
 
 export const UserNav = () => {
-    const isAuth = false
+    const isAuth = true
     return isAuth ? <LoginedUserNav /> : <UnLoginedUserNav />
 }


### PR DESCRIPTION
## 🔘Part

- [x] FE
- [ ] NAV
- [ ] USER-NAV

  <br/>

## 🔎 작업 내용

- 네비게이션 중 로그인한 사용자에게 제공할 테마, 알람, 캘린더 버튼에 대한 팝업 UI를 추가했고, 프로필 사진을 클릭할 경우 생기는 유저 메뉴를 구현

  <br/>

## 이미지 첨부
<img width="342" alt="스크린샷 2025-03-19 오전 10 08 00" src="https://github.com/user-attachments/assets/615a0eef-1458-4f89-af42-c432b2bfa00e" />
<img width="312" alt="스크린샷 2025-03-19 오전 10 08 05" src="https://github.com/user-attachments/assets/239f9fdf-0771-4f0d-bed8-ecf1dd4d7b6f" />


<br/>

## 🔧 앞으로의 과제

- 로그인 기능 구현

  <br/>

## ➕ 이슈 링크

- [DF-87]

<br/>


[DF-87]: https://vino-private.atlassian.net/browse/DF-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ